### PR TITLE
feat(devtools): implementing feedback from community

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -70,12 +70,32 @@
                   <path d="M17.65 6.35A7.95 7.95 0 0 0 12 4V1L7 6l5 5V7a6 6 0 1 1-6 6H4a8 8 0 1 0 13.65-6.65z" />
                 </svg>
               </button>
+              <div class="view-mode-toggle" role="group" aria-label="Component view mode">
+                <button
+                  class="toolbar-button icon-only ${viewMode === 'tree' ? 'active' : ''}"
+                  click.trigger="setViewMode('tree')"
+                  title="Tree view"
+                  aria-label="Tree view"
+                  aria-pressed="${viewMode === 'tree'}"
+                >
+                  <span class="view-mode-icon">🌳</span>
+                </button>
+                <button
+                  class="toolbar-button icon-only ${viewMode === 'list' ? 'active' : ''}"
+                  click.trigger="setViewMode('list')"
+                  title="List view"
+                  aria-label="List view"
+                  aria-pressed="${viewMode === 'list'}"
+                >
+                  <span class="view-mode-icon">☰</span>
+                </button>
+              </div>
               <span
                 class="component-count"
-                if.bind="filteredComponentTreeByTab.length"
+                if.bind="visibleComponentNodes.length"
               >
-                ${filteredComponentTreeByTab.length}${searchQuery ? ' of ' +
-                componentTree.length : ''} ${activeTab === 'all' ? 'component' : activeTab.slice(0, -1)}${filteredComponentTreeByTab.length
+                ${visibleComponentNodes.length}${searchQuery ? ' of ' +
+                totalComponentNodeCount : ''} ${activeTab === 'all' ? 'component' : activeTab.slice(0, -1)}${visibleComponentNodes.length
                 !== 1 ? 's' : ''}
               </span>
             </div>
@@ -158,7 +178,7 @@
             </div>
 
             <div
-              if.bind="aureliaDetected && componentTree.length && !filteredComponentTreeByTab.length && searchQuery"
+              if.bind="aureliaDetected && componentTree.length && !visibleComponentNodes.length && searchQuery"
               class="empty-components"
             >
               <div class="empty-icon">🔍</div>
@@ -172,32 +192,35 @@
               </button>
             </div>
 
-            <div class="component-tree" if.bind="aureliaDetected && filteredComponentTreeByTab.length">
+            <div class="component-tree" if.bind="aureliaDetected && visibleComponentNodes.length">
               <div
-                repeat.for="component of filteredComponentTreeByTab"
-                class="component-tree-item"
+                repeat.for="item of visibleComponentNodes"
+                class="component-tree-row"
               >
                 <div
-                  class="component-item ${selectedComponentId === component.id ? 'selected' : ''}"
-                  click.trigger="selectComponent(component.id)"
-                  mouseenter.trigger="highlightComponent(component)"
+                  class="component-item ${selectedComponentId === item.node.id ? 'selected' : ''}"
+                  style="padding-left: ${(viewMode === 'list' ? 0 : item.depth * 18)}px"
+                  title="${item.node.domPath || item.node.name}"
+                  click.trigger="selectComponent(item.node.id)"
+                  mouseenter.trigger="highlightComponent(item.node)"
                   mouseleave.trigger="unhighlightComponent()"
                 >
                   <button
                     class="expand-toggle"
-                    css="visibility: ${component.children.length ? 'visible' : 'hidden'}"
-                    click.trigger="toggleComponentExpansion(component.id)"
+                    css="visibility: ${(item.node.children.length && viewMode === 'tree') ? 'visible' : 'hidden'}"
+                    disabled.bind="viewMode === 'list'"
+                    click.trigger="handleExpandToggle(item.node, $event)"
                   >
                     <svg
                       width="8"
                       height="8"
                       viewBox="0 0 8 8"
-                      class="expand-icon ${component.expanded ? 'expanded' : ''}"
+                      class="expand-icon ${item.node.expanded ? 'expanded' : ''}"
                     >
                       <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
                     </svg>
                   </button>
-                  <span class="component-icon ${component.type}">
+                  <span class="component-icon ${item.node.type}">
                     <svg
                       width="12"
                       height="12"
@@ -205,64 +228,24 @@
                       fill="currentColor"
                     >
                       <path
-                        if.bind="component.type === 'custom-element'"
+                        if.bind="item.node.type === 'custom-element'"
                         d="M2 2h8v2H2V2zm0 3h8v5H2V5z"
                       />
                       <path
-                        if.bind="component.type === 'custom-attribute'"
+                        if.bind="item.node.type === 'custom-attribute'"
                         d="M6 1L1 6l5 5 5-5-5-5z"
                       />
                     </svg>
                   </span>
-                  <span class="component-name ${component.type}"
-                    >&lt;${component.name}&gt;</span
-                  >
+                  <span class="component-name ${item.node.type}">
+                    <span if.bind="item.node.type === 'custom-element'">&lt;${item.node.name}&gt;</span>
+                    <span if.bind="item.node.type === 'custom-attribute'">@${item.node.name}</span>
+                  </span>
                   <span
-                    if.bind="component.hasAttributes"
+                    if.bind="item.node.data.kind === 'element' && item.node.data.info.customAttributesInfo.length"
                     class="component-badge"
-                    >${component.children.length}</span
+                    >${item.node.data.info.customAttributesInfo.length}</span
                   >
-                </div>
-
-                <div
-                  if.bind="component.expanded && component.children.length"
-                  class="component-children"
-                >
-                  <div
-                    repeat.for="child of component.children"
-                    class="component-tree-item"
-                  >
-                    <div
-                      class="component-item ${selectedComponentId === child.id ? 'selected' : ''}"
-                      click.trigger="selectComponent(child.id)"
-                      mouseenter.trigger="highlightComponent(child)"
-                      mouseleave.trigger="unhighlightComponent()"
-                    >
-                      <button class="expand-toggle" style="visibility: hidden">
-                        <!-- No expand button for leaf nodes -->
-                      </button>
-                      <span class="component-icon ${child.type}">
-                        <svg
-                          width="12"
-                          height="12"
-                          viewBox="0 0 12 12"
-                          fill="currentColor"
-                        >
-                          <path
-                            if.bind="child.type === 'custom-element'"
-                            d="M2 2h8v2H2V2zm0 3h8v5H2V5z"
-                          />
-                          <path
-                            if.bind="child.type === 'custom-attribute'"
-                            d="M6 1L1 6l5 5 5-5-5-5z"
-                          />
-                        </svg>
-                      </span>
-                      <span class="component-name ${child.type}"
-                        >${child.name}</span
-                      >
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
@@ -299,10 +282,21 @@
             if.bind="selectedComponentId && selectedElement"
             class="component-details"
           >
+            <nav class="component-breadcrumbs" if.bind="breadcrumbSegments.length">
+              <template repeat.for="crumb of breadcrumbSegments; index as i">
+                <button
+                  class="breadcrumb-item ${crumb.type} ${crumb.id === selectedComponentId ? 'active' : ''}"
+                  click.trigger="selectComponent(crumb.id)"
+                >
+                  ${crumb.label}
+                </button>
+                <span class="breadcrumb-separator" if.bind="i < breadcrumbSegments.length - 1">›</span>
+              </template>
+            </nav>
             <div class="details-header">
               <div class="selected-component-info">
                 <span
-                  class="component-icon ${selectedElement ? 'custom-element' : 'custom-attribute'}"
+                  class="component-icon ${selectedNodeType}"
                 >
                   <svg
                     width="16"
@@ -311,18 +305,22 @@
                     fill="currentColor"
                   >
                     <path
-                      if.bind="selectedElement"
+                      if.bind="selectedNodeType === 'custom-element'"
                       d="M2 2h8v2H2V2zm0 3h8v5H2V5z"
                     />
                     <path
-                      if.bind="!selectedElement"
+                      if.bind="selectedNodeType === 'custom-attribute'"
                       d="M6 1L1 6l5 5 5-5-5-5z"
                     />
                   </svg>
                 </span>
                 <span class="selected-component-name">
-                  ${selectedElement ? '<' + selectedElement.name + '>' : 'Custom
-                  Attribute'}
+                  <span if.bind="selectedNodeType === 'custom-element'">
+                    &lt;${selectedElement ? selectedElement.name : 'component'}&gt;
+                  </span>
+                  <span if.bind="selectedNodeType === 'custom-attribute'">
+                    @${selectedElement ? selectedElement.name : 'attribute'}
+                  </span>
                 </span>
               </div>
             </div>
@@ -359,7 +357,10 @@
                       class="property-item"
                     >
                       <div class="property-row">
-                        <div class="property-main">
+                        <div
+                          class="property-main ${bindable.canExpand ? 'expandable' : ''}"
+                          click.trigger="handlePropertyRowClick(bindable, $event)"
+                        >
                           <button
                             class="expand-button"
                             css="visibility: ${bindable.canExpand ? 'visible' : 'hidden'}"
@@ -429,7 +430,10 @@
                             class="child-property"
                           >
                             <div class="property-row">
-                              <div class="property-main">
+                              <div
+                                class="property-main ${childProp.canExpand ? 'expandable' : ''}"
+                                click.trigger="handlePropertyRowClick(childProp, $event)"
+                              >
                                 <button
                                   class="expand-button"
                                   css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}"
@@ -509,7 +513,10 @@
                   <ul class="properties-list" else>
                     <li repeat.for="property of selectedElement.properties" class="property-item">
                       <div class="property-row">
-                        <div class="property-main">
+                        <div
+                          class="property-main ${property.canExpand ? 'expandable' : ''}"
+                          click.trigger="handlePropertyRowClick(property, $event)"
+                        >
                           <button class="expand-button" css="visibility: ${property.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(property)">
                             <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${property.isExpanded ? 'expanded' : ''}">
                               <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -533,7 +540,10 @@
                           <div if.bind="!property.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                           <div repeat.for="childProp of property.expandedValue.properties" class="child-property">
                             <div class="property-row">
-                              <div class="property-main">
+                              <div
+                                class="property-main ${childProp.canExpand ? 'expandable' : ''}"
+                                click.trigger="handlePropertyRowClick(childProp, $event)"
+                              >
                                 <button class="expand-button" css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(childProp)">
                                   <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${childProp.isExpanded ? 'expanded' : ''}">
                                     <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -557,7 +567,10 @@
                                 <div if.bind="!childProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                 <div repeat.for="nestedProp of childProp.expandedValue.properties" class="child-property">
                                   <div class="property-row">
-                                    <div class="property-main">
+                                    <div
+                                      class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
+                                      click.trigger="handlePropertyRowClick(nestedProp, $event)"
+                                    >
                                       <button class="expand-button" css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nestedProp)">
                                         <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nestedProp.isExpanded ? 'expanded' : ''}">
                                           <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -581,7 +594,10 @@
                                       <div if.bind="!nestedProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                       <div repeat.for="deepProp of nestedProp.expandedValue.properties" class="child-property">
                                         <div class="property-row">
-                                          <div class="property-main">
+                                          <div
+                                            class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
+                                            click.trigger="handlePropertyRowClick(deepProp, $event)"
+                                          >
                                             <button class="expand-button" css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deepProp)">
                                               <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deepProp.isExpanded ? 'expanded' : ''}">
                                                 <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -601,11 +617,14 @@
                                             </span>
                                           </div>
 
-                                          <div if.bind="deepProp.isExpanded && deepProp.expandedValue" class="property-children">
-                                            <div if.bind="!deepProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                            <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
-                                              <div class="property-row">
-                                                <div class="property-main">
+                                        <div if.bind="deepProp.isExpanded && deepProp.expandedValue" class="property-children">
+                                          <div if.bind="!deepProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
+                                          <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
+                                            <div class="property-row">
+                                              <div
+                                                class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
+                                                click.trigger="handlePropertyRowClick(deeperProp, $event)"
+                                              >
                                                   <button class="expand-button" css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeperProp)">
                                                     <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeperProp.isExpanded ? 'expanded' : ''}">
                                                       <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -653,7 +672,10 @@
                   <ul class="properties-list" else>
                     <li repeat.for="ctrlProp of selectedElement.controller.properties" class="property-item">
                       <div class="property-row">
-                        <div class="property-main">
+                        <div
+                          class="property-main ${ctrlProp.canExpand ? 'expandable' : ''}"
+                          click.trigger="handlePropertyRowClick(ctrlProp, $event)"
+                        >
                           <button class="expand-button" css="visibility: ${ctrlProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(ctrlProp)">
                             <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${ctrlProp.isExpanded ? 'expanded' : ''}">
                               <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -678,7 +700,10 @@
                           <ul class="properties-list" if.bind="ctrlProp.expandedValue && ctrlProp.expandedValue.properties.length">
                             <li repeat.for="nested of ctrlProp.expandedValue.properties" class="property-item">
                               <div class="property-row">
-                                <div class="property-main">
+                                <div
+                                  class="property-main ${nested.canExpand ? 'expandable' : ''}"
+                                  click.trigger="handlePropertyRowClick(nested, $event)"
+                                >
                                   <button class="expand-button" css="visibility: ${nested.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nested)">
                                     <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nested.isExpanded ? 'expanded' : ''}">
                                       <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -703,7 +728,10 @@
                                   <ul class="properties-list" if.bind="nested.expandedValue && nested.expandedValue.properties.length">
                                     <li repeat.for="deep of nested.expandedValue.properties" class="property-item">
                                       <div class="property-row">
-                                        <div class="property-main">
+                                        <div
+                                          class="property-main ${deep.canExpand ? 'expandable' : ''}"
+                                          click.trigger="handlePropertyRowClick(deep, $event)"
+                                        >
                                           <button class="expand-button" css="visibility: ${deep.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deep)">
                                             <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deep.isExpanded ? 'expanded' : ''}">
                                               <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -728,7 +756,10 @@
                                           <ul class="properties-list" if.bind="deep.expandedValue && deep.expandedValue.properties.length">
                                             <li repeat.for="deeper of deep.expandedValue.properties" class="property-item">
                                               <div class="property-row">
-                                                <div class="property-main">
+                                                <div
+                                                  class="property-main ${deeper.canExpand ? 'expandable' : ''}"
+                                                  click.trigger="handlePropertyRowClick(deeper, $event)"
+                                                >
                                                   <button class="expand-button" css="visibility: ${deeper.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeper)">
                                                     <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeper.isExpanded ? 'expanded' : ''}">
                                                       <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -770,7 +801,10 @@
                                   class="child-property"
                                 >
                                   <div class="property-row">
-                                    <div class="property-main">
+                                    <div
+                                      class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
+                                      click.trigger="handlePropertyRowClick(nestedProp, $event)"
+                                    >
                                       <button
                                         class="expand-button"
                                         css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}"
@@ -847,7 +881,10 @@
                                         class="child-property"
                                       >
                                         <div class="property-row">
-                                          <div class="property-main">
+                                          <div
+                                            class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
+                                            click.trigger="handlePropertyRowClick(deepProp, $event)"
+                                          >
                                             <button
                                               class="expand-button"
                                               css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}"
@@ -914,7 +951,10 @@
                                               class="child-property"
                                             >
                                               <div class="property-row">
-                                                <div class="property-main">
+                                                <div
+                                                  class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
+                                                  click.trigger="handlePropertyRowClick(deeperProp, $event)"
+                                                >
                                                   <button
                                                     class="expand-button"
                                                     css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}"
@@ -1014,7 +1054,10 @@
                         <ul class="properties-list" else>
                           <li repeat.for="bindable of attribute.bindables" class="property-item">
                             <div class="property-row">
-                              <div class="property-main">
+                              <div
+                                class="property-main ${bindable.canExpand ? 'expandable' : ''}"
+                                click.trigger="handlePropertyRowClick(bindable, $event)"
+                              >
                                 <button
                                   class="expand-button"
                                   css="visibility: ${bindable.canExpand ? 'visible' : 'hidden'}"
@@ -1052,7 +1095,10 @@
                                 <div if.bind="!bindable.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                 <div repeat.for="childProp of bindable.expandedValue.properties" class="child-property">
                                   <div class="property-row">
-                                    <div class="property-main">
+                                    <div
+                                      class="property-main ${childProp.canExpand ? 'expandable' : ''}"
+                                      click.trigger="handlePropertyRowClick(childProp, $event)"
+                                    >
                                       <button class="expand-button" css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(childProp)">
                                         <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${childProp.isExpanded ? 'expanded' : ''}">
                                           <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1072,7 +1118,10 @@
                                       <div if.bind="!childProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                       <div repeat.for="nestedProp of childProp.expandedValue.properties" class="child-property">
                                         <div class="property-row">
-                                          <div class="property-main">
+                                          <div
+                                            class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
+                                            click.trigger="handlePropertyRowClick(nestedProp, $event)"
+                                          >
                                             <button class="expand-button" css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nestedProp)">
                                               <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nestedProp.isExpanded ? 'expanded' : ''}">
                                                 <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1092,7 +1141,10 @@
                                             <div if.bind="!nestedProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                             <div repeat.for="deepProp of nestedProp.expandedValue.properties" class="child-property">
                                               <div class="property-row">
-                                                <div class="property-main">
+                                                <div
+                                                  class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
+                                                  click.trigger="handlePropertyRowClick(deepProp, $event)"
+                                                >
                                                   <button class="expand-button" css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deepProp)">
                                                     <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deepProp.isExpanded ? 'expanded' : ''}">
                                                       <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1116,7 +1168,10 @@
                                                   <div if.bind="!deepProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                                   <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
                                                     <div class="property-row">
-                                                      <div class="property-main">
+                                                      <div
+                                                        class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
+                                                        click.trigger="handlePropertyRowClick(deeperProp, $event)"
+                                                      >
                                                         <button class="expand-button" css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeperProp)">
                                                           <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeperProp.isExpanded ? 'expanded' : ''}">
                                                             <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1163,7 +1218,10 @@
                         <ul class="properties-list" else>
                           <li repeat.for="property of attribute.properties" class="property-item">
                             <div class="property-row">
-                              <div class="property-main">
+                              <div
+                                class="property-main ${property.canExpand ? 'expandable' : ''}"
+                                click.trigger="handlePropertyRowClick(property, $event)"
+                              >
                                 <button class="expand-button" css="visibility: ${property.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(property)">
                                   <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${property.isExpanded ? 'expanded' : ''}">
                                     <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1183,7 +1241,10 @@
                                 <div if.bind="!property.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                 <div repeat.for="childProp of property.expandedValue.properties" class="child-property">
                                   <div class="property-row">
-                                    <div class="property-main">
+                                    <div
+                                      class="property-main ${childProp.canExpand ? 'expandable' : ''}"
+                                      click.trigger="handlePropertyRowClick(childProp, $event)"
+                                    >
                                       <button class="expand-button" css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(childProp)">
                                         <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${childProp.isExpanded ? 'expanded' : ''}">
                                           <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1207,7 +1268,10 @@
                                       <div if.bind="!childProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                       <div repeat.for="nestedProp of childProp.expandedValue.properties" class="child-property">
                                         <div class="property-row">
-                                          <div class="property-main">
+                                          <div
+                                            class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
+                                            click.trigger="handlePropertyRowClick(nestedProp, $event)"
+                                          >
                                             <button class="expand-button" css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nestedProp)">
                                               <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nestedProp.isExpanded ? 'expanded' : ''}">
                                                 <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1231,7 +1295,10 @@
                                             <div if.bind="!nestedProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
                                             <div repeat.for="deepProp of nestedProp.expandedValue.properties" class="child-property">
                                               <div class="property-row">
-                                                <div class="property-main">
+                                                <div
+                                                  class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
+                                                  click.trigger="handlePropertyRowClick(deepProp, $event)"
+                                                >
                                                   <button class="expand-button" css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deepProp)">
                                                     <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deepProp.isExpanded ? 'expanded' : ''}">
                                                       <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
@@ -1253,9 +1320,12 @@
 
                                                 <div if.bind="deepProp.isExpanded && deepProp.expandedValue" class="property-children">
                                                   <div if.bind="!deepProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                                  <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
-                                                    <div class="property-row">
-                                                      <div class="property-main">
+                                            <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
+                                              <div class="property-row">
+                                                <div
+                                                  class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
+                                                  click.trigger="handlePropertyRowClick(deeperProp, $event)"
+                                                >
                                                         <button class="expand-button" css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeperProp)">
                                                           <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeperProp.isExpanded ? 'expanded' : ''}">
                                                             <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />

--- a/src/app.html
+++ b/src/app.html
@@ -345,155 +345,68 @@
                   <span class="property-count" if.bind="selectedElement.bindables.length">(${selectedElement.bindables.length})</span>
                 </div>
                 <div class="section-content">
-                  <div
-                    if.bind="!selectedElement.bindables.length"
-                    class="empty-state"
-                  >
-                    No bindable properties
-                  </div>
+                  <div if.bind="!selectedElement.bindables.length" class="empty-state">No bindable properties</div>
                   <ul class="properties-list" else>
                     <li
-                      repeat.for="bindable of selectedElement.bindables"
+                      repeat.for="row of getPropertyRows(selectedElement.bindables, propertyRowsRevision)"
                       class="property-item"
+                      style="padding-left: ${row.depth * 16}px"
                     >
                       <div class="property-row">
                         <div
-                          class="property-main ${bindable.canExpand ? 'expandable' : ''}"
-                          click.trigger="handlePropertyRowClick(bindable, $event)"
+                          class="property-main ${row.property.canExpand ? 'expandable' : ''}"
+                          click.trigger="handlePropertyRowClick(row.property, $event)"
                         >
                           <button
                             class="expand-button"
-                            css="visibility: ${bindable.canExpand ? 'visible' : 'hidden'}"
-                            click.trigger="togglePropertyExpansion(bindable)"
+                            css="visibility: ${row.property.canExpand ? 'visible' : 'hidden'}"
+                            click.trigger="togglePropertyExpansion(row.property)"
                           >
                             <svg
                               width="8"
                               height="8"
                               viewBox="0 0 8 8"
-                              class="expand-icon ${bindable.isExpanded ? 'expanded' : ''}"
+                              class="expand-icon ${row.property.isExpanded ? 'expanded' : ''}"
                             >
                               <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
                             </svg>
                           </button>
-                          <span class="property-name">${bindable.name}</span>
+                          <span class="property-name">${row.property.name}</span>
                           <span class="property-separator">:</span>
                           <span class="property-value-wrapper">
                             <span
-                              if.bind="!bindable.isEditing"
-                              class="property-value ${bindable.type} ${bindable.canEdit ? 'editable' : 'readonly'}"
-                              dblclick.trigger="bindable.canEdit ? editProperty(bindable) : null"
-                              title="${bindable.canEdit ? 'Double-click to edit' : 'Read-only property'}"
+                              if.bind="!row.property.isEditing"
+                              class="property-value ${row.property.type} ${row.property.canEdit ? 'editable' : 'readonly'}"
+                              dblclick.trigger="row.property.canEdit ? editProperty(row.property) : null"
+                              title="${row.property.canEdit ? 'Double-click to edit' : 'Read-only property'}"
                             >
-                              <span if.bind="bindable.type === 'string'">"</span
-                              >${bindable.value}<span
-                                if.bind="bindable.type === 'string'"
+                              <span if.bind="row.property.type === 'string'">"</span>${row.property.value}<span
+                                if.bind="row.property.type === 'string'"
                                 >"</span
                               >
                             </span>
 
                             <select
-                              if.bind="bindable.isEditing && bindable.type === 'boolean'"
+                              if.bind="row.property.isEditing && row.property.type === 'boolean'"
                               class="property-editor"
-                              value.bind="bindable.value ? 'true' : 'false'"
-                              change.trigger="saveProperty(bindable, $event.target.value)"
-                              blur.trigger="saveProperty(bindable, $event.target.value)"
+                              value.bind="row.property.value ? 'true' : 'false'"
+                              change.trigger="saveProperty(row.property, $event.target.value)"
+                              blur.trigger="saveProperty(row.property, $event.target.value)"
                             >
                               <option value="true">true</option>
                               <option value="false">false</option>
                             </select>
                             <input
-                              if.bind="bindable.isEditing && bindable.type !== 'boolean'"
+                              if.bind="row.property.isEditing && row.property.type !== 'boolean'"
                               class="property-editor"
                               type="text"
-                              value.bind="bindable.value"
-                              keydown.trigger="$event.code === 'Enter' ? saveProperty(bindable, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(bindable) : null)"
-                              blur.trigger="saveProperty(bindable, $event.target.value)"
-                              placeholder="Enter ${bindable.type} value (ESC to cancel)"
+                              value.bind="row.property.value"
+                              keydown.trigger="$event.code === 'Enter' ? saveProperty(row.property, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(row.property) : null)"
+                              blur.trigger="saveProperty(row.property, $event.target.value)"
+                              placeholder="Enter ${row.property.type} value (ESC to cancel)"
                               focus.trigger="$event.target.select()"
                             />
                           </span>
-                        </div>
-
-                        <!-- Expanded child properties -->
-                        <div
-                          if.bind="bindable.isExpanded && bindable.expandedValue"
-                          class="property-children"
-                        >
-                          <div
-                            if.bind="!bindable.expandedValue.properties.length"
-                            class="empty-object"
-                          >
-                            Object has no enumerable properties
-                          </div>
-                          <div
-                            repeat.for="childProp of bindable.expandedValue.properties"
-                            class="child-property"
-                          >
-                            <div class="property-row">
-                              <div
-                                class="property-main ${childProp.canExpand ? 'expandable' : ''}"
-                                click.trigger="handlePropertyRowClick(childProp, $event)"
-                              >
-                                <button
-                                  class="expand-button"
-                                  css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}"
-                                  click.trigger="togglePropertyExpansion(childProp)"
-                                >
-                                  <svg
-                                    width="8"
-                                    height="8"
-                                    viewBox="0 0 8 8"
-                                    class="expand-icon ${childProp.isExpanded ? 'expanded' : ''}"
-                                  >
-                                    <path
-                                      d="M2 2 L6 4 L2 6 Z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </button>
-                                <span class="property-name"
-                                  >${childProp.name}</span
-                                >
-                                <span class="property-separator">:</span>
-                                <span class="property-value-wrapper">
-                                  <span
-                                    if.bind="!childProp.isEditing"
-                                    class="property-value ${childProp.type} ${childProp.canEdit ? 'editable' : 'readonly'}"
-                                    dblclick.trigger="childProp.canEdit ? editProperty(childProp) : null"
-                                    title="${childProp.canEdit ? 'Double-click to edit' : 'Read-only property'}"
-                                  >
-                                    <span if.bind="childProp.type === 'string'"
-                                      >"</span
-                                    >${childProp.value}<span
-                                      if.bind="childProp.type === 'string'"
-                                      >"</span
-                                    >
-                                  </span>
-
-                                  <select
-                                    if.bind="childProp.isEditing && childProp.type === 'boolean'"
-                                    class="property-editor"
-                                    value.bind="childProp.value ? 'true' : 'false'"
-                                    change.trigger="saveProperty(childProp, $event.target.value)"
-                                    blur.trigger="saveProperty(childProp, $event.target.value)"
-                                  >
-                                    <option value="true">true</option>
-                                    <option value="false">false</option>
-                                  </select>
-                                  <input
-                                    if.bind="childProp.isEditing && childProp.type !== 'boolean'"
-                                    class="property-editor"
-                                    type="text"
-                                    value.bind="childProp.value"
-                                    keydown.trigger="$event.code === 'Enter' ? saveProperty(childProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(childProp) : null)"
-                                    blur.trigger="saveProperty(childProp, $event.target.value)"
-                                    placeholder="Enter ${childProp.type} value (ESC to cancel)"
-                                    focus.trigger="$event.target.select()"
-                                  />
-                                </span>
-                              </div>
-                            </div>
-                          </div>
                         </div>
                       </div>
                     </li>
@@ -502,7 +415,6 @@
 
                 <div class="properties-separator"></div>
 
-                <!-- Non-bindable Properties for selected element -->
                 <div class="section-header">
                   <span class="section-icon">🏠</span>
                   <span class="section-title">Properties</span>
@@ -511,157 +423,74 @@
                 <div class="section-content">
                   <div if.bind="!selectedElement.properties.length" class="empty-state">No properties</div>
                   <ul class="properties-list" else>
-                    <li repeat.for="property of selectedElement.properties" class="property-item">
+                    <li
+                      repeat.for="row of getPropertyRows(selectedElement.properties, propertyRowsRevision)"
+                      class="property-item"
+                      style="padding-left: ${row.depth * 16}px"
+                    >
                       <div class="property-row">
                         <div
-                          class="property-main ${property.canExpand ? 'expandable' : ''}"
-                          click.trigger="handlePropertyRowClick(property, $event)"
+                          class="property-main ${row.property.canExpand ? 'expandable' : ''}"
+                          click.trigger="handlePropertyRowClick(row.property, $event)"
                         >
-                          <button class="expand-button" css="visibility: ${property.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(property)">
-                            <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${property.isExpanded ? 'expanded' : ''}">
+                          <button
+                            class="expand-button"
+                            css="visibility: ${row.property.canExpand ? 'visible' : 'hidden'}"
+                            click.trigger="togglePropertyExpansion(row.property)"
+                          >
+                            <svg
+                              width="8"
+                              height="8"
+                              viewBox="0 0 8 8"
+                              class="expand-icon ${row.property.isExpanded ? 'expanded' : ''}"
+                            >
                               <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
                             </svg>
                           </button>
-                          <span class="property-name">${property.name}</span>
+                          <span class="property-name">${row.property.name}</span>
                           <span class="property-separator">:</span>
                           <span class="property-value-wrapper">
-                            <span if.bind="!property.isEditing" class="property-value ${property.type} ${property.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="property.canEdit ? editProperty(property) : null" title="${property.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                              <span if.bind="property.type === 'string'">"</span>${property.value}<span if.bind="property.type === 'string'">"</span>
+                            <span
+                              if.bind="!row.property.isEditing"
+                              class="property-value ${row.property.type} ${row.property.canEdit ? 'editable' : 'readonly'}"
+                              dblclick.trigger="row.property.canEdit ? editProperty(row.property) : null"
+                              title="${row.property.canEdit ? 'Double-click to edit' : 'Read-only property'}"
+                            >
+                              <span if.bind="row.property.type === 'string'">"</span>${row.property.value}<span
+                                if.bind="row.property.type === 'string'"
+                                >"</span
+                              >
                             </span>
-                            <select if.bind="property.isEditing && property.type === 'boolean'" class="property-editor" value.bind="property.value ? 'true' : 'false'" change.trigger="saveProperty(property, $event.target.value)" blur.trigger="saveProperty(property, $event.target.value)">
+
+                            <select
+                              if.bind="row.property.isEditing && row.property.type === 'boolean'"
+                              class="property-editor"
+                              value.bind="row.property.value ? 'true' : 'false'"
+                              change.trigger="saveProperty(row.property, $event.target.value)"
+                              blur.trigger="saveProperty(row.property, $event.target.value)"
+                            >
                               <option value="true">true</option>
                               <option value="false">false</option>
                             </select>
-                            <input if.bind="property.isEditing && property.type !== 'boolean'" class="property-editor" type="text" value.bind="property.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(property, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(property) : null)" blur.trigger="saveProperty(property, $event.target.value)" placeholder="Enter ${property.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
+                            <input
+                              if.bind="row.property.isEditing && row.property.type !== 'boolean'"
+                              class="property-editor"
+                              type="text"
+                              value.bind="row.property.value"
+                              keydown.trigger="$event.code === 'Enter' ? saveProperty(row.property, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(row.property) : null)"
+                              blur.trigger="saveProperty(row.property, $event.target.value)"
+                              placeholder="Enter ${row.property.type} value (ESC to cancel)"
+                              focus.trigger="$event.target.select()"
+                            />
                           </span>
-                        </div>
-
-                        <div if.bind="property.isExpanded && property.expandedValue" class="property-children">
-                          <div if.bind="!property.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                          <div repeat.for="childProp of property.expandedValue.properties" class="child-property">
-                            <div class="property-row">
-                              <div
-                                class="property-main ${childProp.canExpand ? 'expandable' : ''}"
-                                click.trigger="handlePropertyRowClick(childProp, $event)"
-                              >
-                                <button class="expand-button" css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(childProp)">
-                                  <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${childProp.isExpanded ? 'expanded' : ''}">
-                                    <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                  </svg>
-                                </button>
-                                <span class="property-name">${childProp.name}</span>
-                                <span class="property-separator">:</span>
-                                <span class="property-value-wrapper">
-                                  <span if.bind="!childProp.isEditing" class="property-value ${childProp.type} ${childProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="childProp.canEdit ? editProperty(childProp) : null" title="${childProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                    <span if.bind="childProp.type === 'string'">"</span>${childProp.value}<span if.bind="childProp.type === 'string'">"</span>
-                                  </span>
-                                  <select if.bind="childProp.isEditing && childProp.type === 'boolean'" class="property-editor" value.bind="childProp.value ? 'true' : 'false'" change.trigger="saveProperty(childProp, $event.target.value)" blur.trigger="saveProperty(childProp, $event.target.value)">
-                                    <option value="true">true</option>
-                                    <option value="false">false</option>
-                                  </select>
-                                  <input if.bind="childProp.isEditing && childProp.type !== 'boolean'" class="property-editor" type="text" value.bind="childProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(childProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(childProp) : null)" blur.trigger="saveProperty(childProp, $event.target.value)" placeholder="Enter ${childProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                </span>
-                              </div>
-
-                              <div if.bind="childProp.isExpanded && childProp.expandedValue" class="property-children">
-                                <div if.bind="!childProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                <div repeat.for="nestedProp of childProp.expandedValue.properties" class="child-property">
-                                  <div class="property-row">
-                                    <div
-                                      class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
-                                      click.trigger="handlePropertyRowClick(nestedProp, $event)"
-                                    >
-                                      <button class="expand-button" css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nestedProp)">
-                                        <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nestedProp.isExpanded ? 'expanded' : ''}">
-                                          <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                        </svg>
-                                      </button>
-                                      <span class="property-name">${nestedProp.name}</span>
-                                      <span class="property-separator">:</span>
-                                      <span class="property-value-wrapper">
-                                        <span if.bind="!nestedProp.isEditing" class="property-value ${nestedProp.type} ${nestedProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="nestedProp.canEdit ? editProperty(nestedProp) : null" title="${nestedProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                          <span if.bind="nestedProp.type === 'string'">"</span>${nestedProp.value}<span if.bind="nestedProp.type === 'string'">"</span>
-                                        </span>
-                                        <select if.bind="nestedProp.isEditing && nestedProp.type === 'boolean'" class="property-editor" value.bind="nestedProp.value ? 'true' : 'false'" change.trigger="saveProperty(nestedProp, $event.target.value)" blur.trigger="saveProperty(nestedProp, $event.target.value)">
-                                          <option value="true">true</option>
-                                          <option value="false">false</option>
-                                        </select>
-                                        <input if.bind="nestedProp.isEditing && nestedProp.type !== 'boolean'" class="property-editor" type="text" value.bind="nestedProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(nestedProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(nestedProp) : null)" blur.trigger="saveProperty(nestedProp, $event.target.value)" placeholder="Enter ${nestedProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                      </span>
-                                    </div>
-
-                                    <div if.bind="nestedProp.isExpanded && nestedProp.expandedValue" class="property-children">
-                                      <div if.bind="!nestedProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                      <div repeat.for="deepProp of nestedProp.expandedValue.properties" class="child-property">
-                                        <div class="property-row">
-                                          <div
-                                            class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
-                                            click.trigger="handlePropertyRowClick(deepProp, $event)"
-                                          >
-                                            <button class="expand-button" css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deepProp)">
-                                              <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deepProp.isExpanded ? 'expanded' : ''}">
-                                                <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                              </svg>
-                                            </button>
-                                            <span class="property-name">${deepProp.name}</span>
-                                            <span class="property-separator">:</span>
-                                            <span class="property-value-wrapper">
-                                              <span if.bind="!deepProp.isEditing" class="property-value ${deepProp.type} ${deepProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deepProp.canEdit ? editProperty(deepProp) : null" title="${deepProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                <span if.bind="deepProp.type === 'string'">"</span>${deepProp.value}<span if.bind="deepProp.type === 'string'">"</span>
-                                              </span>
-                                              <select if.bind="deepProp.isEditing && deepProp.type === 'boolean'" class="property-editor" value.bind="deepProp.value ? 'true' : 'false'" change.trigger="saveProperty(deepProp, $event.target.value)" blur.trigger="saveProperty(deepProp, $event.target.value)">
-                                                <option value="true">true</option>
-                                                <option value="false">false</option>
-                                              </select>
-                                              <input if.bind="deepProp.isEditing && deepProp.type !== 'boolean'" class="property-editor" type="text" value.bind="deepProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deepProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deepProp) : null)" blur.trigger="saveProperty(deepProp, $event.target.value)" placeholder="Enter ${deepProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                            </span>
-                                          </div>
-
-                                        <div if.bind="deepProp.isExpanded && deepProp.expandedValue" class="property-children">
-                                          <div if.bind="!deepProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                          <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
-                                            <div class="property-row">
-                                              <div
-                                                class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
-                                                click.trigger="handlePropertyRowClick(deeperProp, $event)"
-                                              >
-                                                  <button class="expand-button" css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeperProp)">
-                                                    <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeperProp.isExpanded ? 'expanded' : ''}">
-                                                      <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                                    </svg>
-                                                  </button>
-                                                  <span class="property-name">${deeperProp.name}</span>
-                                                  <span class="property-separator">:</span>
-                                                  <span class="property-value-wrapper">
-                                                    <span if.bind="!deeperProp.isEditing" class="property-value ${deeperProp.type} ${deeperProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deeperProp.canEdit ? editProperty(deeperProp) : null" title="${deeperProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                      <span if.bind="deeperProp.type === 'string'">"</span>${deeperProp.value}<span if.bind="deeperProp.type === 'string'">"</span>
-                                                    </span>
-                                                    <select if.bind="deeperProp.isEditing && deeperProp.type === 'boolean'" class="property-editor" value.bind="deeperProp.value ? 'true' : 'false'" change.trigger="saveProperty(deeperProp, $event.target.value)" blur.trigger="saveProperty(deeperProp, $event.target.value)">
-                                                      <option value="true">true</option>
-                                                      <option value="false">false</option>
-                                                    </select>
-                                                    <input if.bind="deeperProp.isEditing && deeperProp.type !== 'boolean'" class="property-editor" type="text" value.bind="deeperProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deeperProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deeperProp) : null)" blur.trigger="saveProperty(deeperProp, $event.target.value)" placeholder="Enter ${deeperProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                                  </span>
-                                                </div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
                         </div>
                       </div>
                     </li>
                   </ul>
                 </div>
 
-                <!-- Controller Internals -->
-                <div class="properties-separator"></div>
+                <div class="properties-separator" if.bind="selectedElement?.controller"></div>
+
                 <div class="section-header" if.bind="selectedElement?.controller">
                   <span class="section-icon">🛠️</span>
                   <span class="section-title">Controller</span>
@@ -670,351 +499,66 @@
                 <div class="section-content" if.bind="selectedElement?.controller">
                   <div if.bind="!selectedElement.controller.properties.length" class="empty-state">No controller fields</div>
                   <ul class="properties-list" else>
-                    <li repeat.for="ctrlProp of selectedElement.controller.properties" class="property-item">
+                    <li
+                      repeat.for="row of getPropertyRows(selectedElement.controller.properties, propertyRowsRevision)"
+                      class="property-item"
+                      style="padding-left: ${row.depth * 16}px"
+                    >
                       <div class="property-row">
                         <div
-                          class="property-main ${ctrlProp.canExpand ? 'expandable' : ''}"
-                          click.trigger="handlePropertyRowClick(ctrlProp, $event)"
+                          class="property-main ${row.property.canExpand ? 'expandable' : ''}"
+                          click.trigger="handlePropertyRowClick(row.property, $event)"
                         >
-                          <button class="expand-button" css="visibility: ${ctrlProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(ctrlProp)">
-                            <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${ctrlProp.isExpanded ? 'expanded' : ''}">
+                          <button
+                            class="expand-button"
+                            css="visibility: ${row.property.canExpand ? 'visible' : 'hidden'}"
+                            click.trigger="togglePropertyExpansion(row.property)"
+                          >
+                            <svg
+                              width="8"
+                              height="8"
+                              viewBox="0 0 8 8"
+                              class="expand-icon ${row.property.isExpanded ? 'expanded' : ''}"
+                            >
                               <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
                             </svg>
                           </button>
-                          <span class="property-name">${ctrlProp.name}</span>
+                          <span class="property-name">${row.property.name}</span>
                           <span class="property-separator">:</span>
                           <span class="property-value-wrapper">
-                            <span if.bind="!ctrlProp.isEditing" class="property-value ${ctrlProp.type} ${ctrlProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="ctrlProp.canEdit ? editProperty(ctrlProp) : null" title="${ctrlProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                              <span if.bind="ctrlProp.type === 'string'">"</span>${ctrlProp.value}<span if.bind="ctrlProp.type === 'string'">"</span>
+                            <span
+                              if.bind="!row.property.isEditing"
+                              class="property-value ${row.property.type} ${row.property.canEdit ? 'editable' : 'readonly'}"
+                              dblclick.trigger="row.property.canEdit ? editProperty(row.property) : null"
+                              title="${row.property.canEdit ? 'Double-click to edit' : 'Read-only property'}"
+                            >
+                              <span if.bind="row.property.type === 'string'">"</span>${row.property.value}<span
+                                if.bind="row.property.type === 'string'"
+                                >"</span
+                              >
                             </span>
-                            <select if.bind="ctrlProp.isEditing && ctrlProp.type === 'boolean'" class="property-editor" value.bind="ctrlProp.value ? 'true' : 'false'" change.trigger="saveProperty(ctrlProp, $event.target.value)" blur.trigger="saveProperty(ctrlProp, $event.target.value)">
+
+                            <select
+                              if.bind="row.property.isEditing && row.property.type === 'boolean'"
+                              class="property-editor"
+                              value.bind="row.property.value ? 'true' : 'false'"
+                              change.trigger="saveProperty(row.property, $event.target.value)"
+                              blur.trigger="saveProperty(row.property, $event.target.value)"
+                            >
                               <option value="true">true</option>
                               <option value="false">false</option>
                             </select>
-                            <input if.bind="ctrlProp.isEditing && ctrlProp.type !== 'boolean'" class="property-editor" type="text" value.bind="ctrlProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(ctrlProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(ctrlProp) : null)" blur.trigger="saveProperty(ctrlProp, $event.target.value)" placeholder="Enter ${ctrlProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
+                            <input
+                              if.bind="row.property.isEditing && row.property.type !== 'boolean'"
+                              class="property-editor"
+                              type="text"
+                              value.bind="row.property.value"
+                              keydown.trigger="$event.code === 'Enter' ? saveProperty(row.property, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(row.property) : null)"
+                              blur.trigger="saveProperty(row.property, $event.target.value)"
+                              placeholder="Enter ${row.property.type} value (ESC to cancel)"
+                              focus.trigger="$event.target.select()"
+                            />
                           </span>
-                        </div>
-
-                        <div if.bind="ctrlProp.isExpanded && ctrlProp.expandedValue" class="property-children">
-                          <div if.bind="ctrlProp.expandedValue && !ctrlProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                          <ul class="properties-list" if.bind="ctrlProp.expandedValue && ctrlProp.expandedValue.properties.length">
-                            <li repeat.for="nested of ctrlProp.expandedValue.properties" class="property-item">
-                              <div class="property-row">
-                                <div
-                                  class="property-main ${nested.canExpand ? 'expandable' : ''}"
-                                  click.trigger="handlePropertyRowClick(nested, $event)"
-                                >
-                                  <button class="expand-button" css="visibility: ${nested.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nested)">
-                                    <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nested.isExpanded ? 'expanded' : ''}">
-                                      <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                    </svg>
-                                  </button>
-                                  <span class="property-name">${nested.name}</span>
-                                  <span class="property-separator">:</span>
-                                  <span class="property-value-wrapper">
-                                    <span if.bind="!nested.isEditing" class="property-value ${nested.type} ${nested.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="nested.canEdit ? editProperty(nested) : null" title="${nested.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                      <span if.bind="nested.type === 'string'">"</span>${nested.value}<span if.bind="nested.type === 'string'">"</span>
-                                    </span>
-                                    <select if.bind="nested.isEditing && nested.type === 'boolean'" class="property-editor" value.bind="nested.value ? 'true' : 'false'" change.trigger="saveProperty(nested, $event.target.value)" blur.trigger="saveProperty(nested, $event.target.value)">
-                                      <option value="true">true</option>
-                                      <option value="false">false</option>
-                                    </select>
-                                    <input if.bind="nested.isEditing && nested.type !== 'boolean'" class="property-editor" type="text" value.bind="nested.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(nested, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(nested) : null)" blur.trigger="saveProperty(nested, $event.target.value)" placeholder="Enter ${nested.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                  </span>
-                                </div>
-
-                                <div if.bind="nested.isExpanded && nested.expandedValue" class="property-children">
-                                  <div if.bind="!nested.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                  <ul class="properties-list" if.bind="nested.expandedValue && nested.expandedValue.properties.length">
-                                    <li repeat.for="deep of nested.expandedValue.properties" class="property-item">
-                                      <div class="property-row">
-                                        <div
-                                          class="property-main ${deep.canExpand ? 'expandable' : ''}"
-                                          click.trigger="handlePropertyRowClick(deep, $event)"
-                                        >
-                                          <button class="expand-button" css="visibility: ${deep.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deep)">
-                                            <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deep.isExpanded ? 'expanded' : ''}">
-                                              <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                            </svg>
-                                          </button>
-                                          <span class="property-name">${deep.name}</span>
-                                          <span class="property-separator">:</span>
-                                          <span class="property-value-wrapper">
-                                            <span if.bind="!deep.isEditing" class="property-value ${deep.type} ${deep.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deep.canEdit ? editProperty(deep) : null" title="${deep.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                              <span if.bind="deep.type === 'string'">"</span>${deep.value}<span if.bind="deep.type === 'string'">"</span>
-                                            </span>
-                                            <select if.bind="deep.isEditing && deep.type === 'boolean'" class="property-editor" value.bind="deep.value ? 'true' : 'false'" change.trigger="saveProperty(deep, $event.target.value)" blur.trigger="saveProperty(deep, $event.target.value)">
-                                              <option value="true">true</option>
-                                              <option value="false">false</option>
-                                            </select>
-                                            <input if.bind="deep.isEditing && deep.type !== 'boolean'" class="property-editor" type="text" value.bind="deep.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deep, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deep) : null)" blur.trigger="saveProperty(deep, $event.target.value)" placeholder="Enter ${deep.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                          </span>
-                                        </div>
-
-                                        <div if.bind="deep.isExpanded && deep.expandedValue" class="property-children">
-                                          <div if.bind="!deep.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                          <ul class="properties-list" if.bind="deep.expandedValue && deep.expandedValue.properties.length">
-                                            <li repeat.for="deeper of deep.expandedValue.properties" class="property-item">
-                                              <div class="property-row">
-                                                <div
-                                                  class="property-main ${deeper.canExpand ? 'expandable' : ''}"
-                                                  click.trigger="handlePropertyRowClick(deeper, $event)"
-                                                >
-                                                  <button class="expand-button" css="visibility: ${deeper.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeper)">
-                                                    <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeper.isExpanded ? 'expanded' : ''}">
-                                                      <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                                    </svg>
-                                                  </button>
-                                                  <span class="property-name">${deeper.name}</span>
-                                                  <span class="property-separator">:</span>
-                                                  <span class="property-value-wrapper">
-                                                    <span if.bind="!deeper.isEditing" class="property-value ${deeper.type} ${deeper.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deeper.canEdit ? editProperty(deeper) : null" title="${deeper.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                      <span if.bind="deeper.type === 'string'">"</span>${deeper.value}<span if.bind="deeper.type === 'string'">"</span>
-                                                    </span>
-                                                    <input if.bind="deeper.isEditing" class="property-editor" type="text" value.bind="deeper.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deeper, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deeper) : null)" blur.trigger="saveProperty(deeper, $event.target.value)" placeholder="Enter ${deeper.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                                  </span>
-                                                </div>
-                                              </div>
-                                            </li>
-                                          </ul>
-                                        </div>
-                                      </div>
-                                    </li>
-                                  </ul>
-                                </div>
-                              </div>
-                            </li>
-                          </ul>
-                        </div>
-                      </div>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </main>
-</div>
-                                  class="child-property"
-                                >
-                                  <div class="property-row">
-                                    <div
-                                      class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
-                                      click.trigger="handlePropertyRowClick(nestedProp, $event)"
-                                    >
-                                      <button
-                                        class="expand-button"
-                                        css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}"
-                                        click.trigger="togglePropertyExpansion(nestedProp)"
-                                      >
-                                        <svg
-                                          width="8"
-                                          height="8"
-                                          viewBox="0 0 8 8"
-                                          class="expand-icon ${nestedProp.isExpanded ? 'expanded' : ''}"
-                                        >
-                                          <path
-                                            d="M2 2 L6 4 L2 6 Z"
-                                            fill="currentColor"
-                                          />
-                                        </svg>
-                                      </button>
-                                      <span class="property-name"
-                                        >${nestedProp.name}</span
-                                      >
-                                      <span class="property-separator">:</span>
-                                      <span class="property-value-wrapper">
-                                        <span
-                                          if.bind="!nestedProp.isEditing"
-                                          class="property-value ${nestedProp.type} ${nestedProp.canEdit ? 'editable' : 'readonly'}"
-                                          dblclick.trigger="nestedProp.canEdit ? editProperty(nestedProp) : null"
-                                          title="${nestedProp.canEdit ? 'Double-click to edit' : 'Read-only property'}"
-                                        >
-                                          <span
-                                            if.bind="nestedProp.type === 'string'"
-                                            >"</span
-                                          >${nestedProp.value}<span
-                                            if.bind="nestedProp.type === 'string'"
-                                            >"</span
-                                          >
-                                        </span>
-
-                                        <select
-                                          if.bind="nestedProp.isEditing && nestedProp.type === 'boolean'"
-                                          class="property-editor"
-                                          value.bind="nestedProp.value ? 'true' : 'false'"
-                                          change.trigger="saveProperty(nestedProp, $event.target.value)"
-                                          blur.trigger="saveProperty(nestedProp, $event.target.value)"
-                                        >
-                                          <option value="true">true</option>
-                                          <option value="false">false</option>
-                                        </select>
-                                        <input
-                                          if.bind="nestedProp.isEditing && nestedProp.type !== 'boolean'"
-                                          class="property-editor"
-                                          type="text"
-                                          value.bind="nestedProp.value"
-                                          keydown.trigger="$event.code === 'Enter' ? saveProperty(nestedProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(nestedProp) : null)"
-                                          blur.trigger="saveProperty(nestedProp, $event.target.value)"
-                                          placeholder="Enter ${nestedProp.type} value (ESC to cancel)"
-                                          focus.trigger="$event.target.select()"
-                                        />
-                                      </span>
-                                    </div>
-
-                                    <!-- Third level nesting -->
-                                    <div
-                                      if.bind="nestedProp.isExpanded && nestedProp.expandedValue"
-                                      class="property-children"
-                                    >
-                                      <div
-                                        if.bind="!nestedProp.expandedValue.properties.length"
-                                        class="empty-object"
-                                      >
-                                        Object has no enumerable properties
-                                      </div>
-                                      <div
-                                        repeat.for="deepProp of nestedProp.expandedValue.properties"
-                                        class="child-property"
-                                      >
-                                        <div class="property-row">
-                                          <div
-                                            class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
-                                            click.trigger="handlePropertyRowClick(deepProp, $event)"
-                                          >
-                                            <button
-                                              class="expand-button"
-                                              css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}"
-                                              click.trigger="togglePropertyExpansion(deepProp)"
-                                            >
-                                              <svg
-                                                width="8"
-                                                height="8"
-                                                viewBox="0 0 8 8"
-                                                class="expand-icon ${deepProp.isExpanded ? 'expanded' : ''}"
-                                              >
-                                                <path
-                                                  d="M2 2 L6 4 L2 6 Z"
-                                                  fill="currentColor"
-                                                />
-                                              </svg>
-                                            </button>
-                                            <span class="property-name"
-                                              >${deepProp.name}</span
-                                            >
-                                            <span class="property-separator">:</span>
-                                            <span class="property-value-wrapper">
-                                              <span
-                                                if.bind="!deepProp.isEditing"
-                                                class="property-value ${deepProp.type} ${deepProp.canEdit ? 'editable' : 'readonly'}"
-                                                dblclick.trigger="deepProp.canEdit ? editProperty(deepProp) : null"
-                                                title="${deepProp.canEdit ? 'Double-click to edit' : 'Read-only property'}"
-                                              >
-                                                <span
-                                                  if.bind="deepProp.type === 'string'"
-                                                  >"</span
-                                                >${deepProp.value}<span
-                                                  if.bind="deepProp.type === 'string'"
-                                                  >"</span
-                                                >
-                                              </span>
-
-                                              <input
-                                                if.bind="deepProp.isEditing"
-                                                class="property-editor"
-                                                type="text"
-                                                value.bind="deepProp.value"
-                                                keydown.trigger="$event.code === 'Enter' ? saveProperty(deepProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deepProp) : null)"
-                                                blur.trigger="saveProperty(deepProp, $event.target.value)"
-                                                placeholder="Enter ${deepProp.type} value (ESC to cancel)"
-                                                focus.trigger="$event.target.select()"
-                                              />
-                                            </span>
-                                          </div>
-
-                                          <!-- Fourth level nesting -->
-                                          <div
-                                            if.bind="deepProp.isExpanded && deepProp.expandedValue"
-                                            class="property-children"
-                                          >
-                                            <div
-                                              if.bind="!deepProp.expandedValue.properties.length"
-                                              class="empty-object"
-                                            >
-                                              Object has no enumerable properties
-                                            </div>
-                                            <div
-                                              repeat.for="deeperProp of deepProp.expandedValue.properties"
-                                              class="child-property"
-                                            >
-                                              <div class="property-row">
-                                                <div
-                                                  class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
-                                                  click.trigger="handlePropertyRowClick(deeperProp, $event)"
-                                                >
-                                                  <button
-                                                    class="expand-button"
-                                                    css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}"
-                                                    click.trigger="togglePropertyExpansion(deeperProp)"
-                                                  >
-                                                    <svg
-                                                      width="8"
-                                                      height="8"
-                                                      viewBox="0 0 8 8"
-                                                      class="expand-icon ${deeperProp.isExpanded ? 'expanded' : ''}"
-                                                    >
-                                                      <path
-                                                        d="M2 2 L6 4 L2 6 Z"
-                                                        fill="currentColor"
-                                                      />
-                                                    </svg>
-                                                  </button>
-                                                  <span class="property-name"
-                                                    >${deeperProp.name}</span
-                                                  >
-                                                  <span class="property-separator">:</span>
-                                                  <span class="property-value-wrapper">
-                                                    <span
-                                                      if.bind="!deeperProp.isEditing"
-                                                      class="property-value ${deeperProp.type} ${deeperProp.canEdit ? 'editable' : 'readonly'}"
-                                                      dblclick.trigger="deeperProp.canEdit ? editProperty(deeperProp) : null"
-                                                      title="${deeperProp.canEdit ? 'Double-click to edit' : 'Read-only property'}"
-                                                    >
-                                                      <span
-                                                        if.bind="deeperProp.type === 'string'"
-                                                        >"</span
-                                                      >${deeperProp.value}<span
-                                                        if.bind="deeperProp.type === 'string'"
-                                                        >"</span
-                                                      >
-                                                    </span>
-
-                                                    <input
-                                                      if.bind="deeperProp.isEditing"
-                                                      class="property-editor"
-                                                      type="text"
-                                                      value.bind="deeperProp.value"
-                                                      keydown.trigger="$event.code === 'Enter' ? saveProperty(deeperProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deeperProp) : null)"
-                                                      blur.trigger="saveProperty(deeperProp, $event.target.value)"
-                                                      placeholder="Enter ${deeperProp.type} value (ESC to cancel)"
-                                                      focus.trigger="$event.target.select()"
-                                                    />
-                                                  </span>
-                                                </div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
                         </div>
                       </div>
                     </li>
@@ -1023,27 +567,18 @@
               </div>
 
               <!-- Custom Attributes -->
-              <div
-                class="properties-section"
-                if.bind="selectedElementAttributes && selectedElementAttributes.length"
-              >
+              <div class="properties-section" if.bind="selectedElementAttributes && selectedElementAttributes.length">
                 <div class="section-header">
                   <span class="section-icon">⚙️</span>
                   <span class="section-title">Custom Attributes</span>
-                  <span class="property-count"
-                    >(${selectedElementAttributes.length})</span
-                  >
+                  <span class="property-count">(${selectedElementAttributes.length})</span>
                 </div>
                 <div class="section-content">
-                  <div
-                    repeat.for="attribute of selectedElementAttributes"
-                    class="attribute-group"
-                  >
+                  <div repeat.for="attribute of selectedElementAttributes" class="attribute-group">
                     <div class="attribute-header">
                       <span class="attribute-name">${attribute.name}</span>
                     </div>
                     <div class="attribute-content">
-                      <!-- Bindables -->
                       <div class="section-header">
                         <span class="section-icon">⚡</span>
                         <span class="section-title">Bindables</span>
@@ -1052,162 +587,50 @@
                       <div class="section-content">
                         <div if.bind="!attribute.bindables.length" class="empty-state">No bindable properties</div>
                         <ul class="properties-list" else>
-                          <li repeat.for="bindable of attribute.bindables" class="property-item">
+                          <li
+                            repeat.for="row of getPropertyRows(attribute.bindables, propertyRowsRevision)"
+                            class="property-item"
+                            style="padding-left: ${row.depth * 16}px"
+                          >
                             <div class="property-row">
                               <div
-                                class="property-main ${bindable.canExpand ? 'expandable' : ''}"
-                                click.trigger="handlePropertyRowClick(bindable, $event)"
+                                class="property-main ${row.property.canExpand ? 'expandable' : ''}"
+                                click.trigger="handlePropertyRowClick(row.property, $event)"
                               >
                                 <button
                                   class="expand-button"
-                                  css="visibility: ${bindable.canExpand ? 'visible' : 'hidden'}"
-                                  click.trigger="togglePropertyExpansion(bindable)"
+                                  css="visibility: ${row.property.canExpand ? 'visible' : 'hidden'}"
+                                  click.trigger="togglePropertyExpansion(row.property)"
                                 >
-                                  <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${bindable.isExpanded ? 'expanded' : ''}">
+                                  <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${row.property.isExpanded ? 'expanded' : ''}">
                                     <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
                                   </svg>
                                 </button>
-                                <span class="property-name">${bindable.name}</span>
+                                <span class="property-name">${row.property.name}</span>
                                 <span class="property-separator">:</span>
                                 <span class="property-value-wrapper">
                                   <span
-                                    if.bind="!bindable.isEditing"
-                                    class="property-value ${bindable.type} ${bindable.canEdit ? 'editable' : 'readonly'}"
-                                    dblclick.trigger="bindable.canEdit ? editProperty(bindable) : null"
-                                    title="${bindable.canEdit ? 'Double-click to edit' : 'Read-only property'}"
+                                    if.bind="!row.property.isEditing"
+                                    class="property-value ${row.property.type} ${row.property.canEdit ? 'editable' : 'readonly'}"
+                                    dblclick.trigger="row.property.canEdit ? editProperty(row.property) : null"
+                                    title="${row.property.canEdit ? 'Double-click to edit' : 'Read-only property'}"
                                   >
-                                    <span if.bind="bindable.type === 'string'">"</span>${bindable.value}<span if.bind="bindable.type === 'string'">"</span>
+                                    <span if.bind="row.property.type === 'string'">"</span>${row.property.value}<span if.bind="row.property.type === 'string'">"</span>
                                   </span>
-                                  <input
-                                    if.bind="bindable.isEditing"
-                                    class="property-editor"
-                                    type="text"
-                                    value.bind="bindable.value"
-                                    keydown.trigger="$event.code === 'Enter' ? saveProperty(bindable, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(bindable) : null)"
-                                    blur.trigger="saveProperty(bindable, $event.target.value)"
-                                    placeholder="Enter ${bindable.type} value (ESC to cancel)"
-                                    focus.trigger="$event.target.select()"
-                                  />
+                                  <select if.bind="row.property.isEditing && row.property.type === 'boolean'" class="property-editor" value.bind="row.property.value ? 'true' : 'false'" change.trigger="saveProperty(row.property, $event.target.value)" blur.trigger="saveProperty(row.property, $event.target.value)">
+                                    <option value="true">true</option>
+                                    <option value="false">false</option>
+                                  </select>
+                                  <input if.bind="row.property.isEditing && row.property.type !== 'boolean'" class="property-editor" type="text" value.bind="row.property.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(row.property, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(row.property) : null)" blur.trigger="saveProperty(row.property, $event.target.value)" placeholder="Enter ${row.property.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
                                 </span>
-                              </div>
-
-                              <div if.bind="bindable.isExpanded && bindable.expandedValue" class="property-children">
-                                <div if.bind="!bindable.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                <div repeat.for="childProp of bindable.expandedValue.properties" class="child-property">
-                                  <div class="property-row">
-                                    <div
-                                      class="property-main ${childProp.canExpand ? 'expandable' : ''}"
-                                      click.trigger="handlePropertyRowClick(childProp, $event)"
-                                    >
-                                      <button class="expand-button" css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(childProp)">
-                                        <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${childProp.isExpanded ? 'expanded' : ''}">
-                                          <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                        </svg>
-                                      </button>
-                                      <span class="property-name">${childProp.name}</span>
-                                      <span class="property-separator">:</span>
-                                      <span class="property-value-wrapper">
-                                        <span if.bind="!childProp.isEditing" class="property-value ${childProp.type} ${childProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="childProp.canEdit ? editProperty(childProp) : null" title="${childProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                          <span if.bind="childProp.type === 'string'">"</span>${childProp.value}<span if.bind="childProp.type === 'string'">"</span>
-                                        </span>
-                                        <input if.bind="childProp.isEditing" class="property-editor" type="text" value.bind="childProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(childProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(childProp) : null)" blur.trigger="saveProperty(childProp, $event.target.value)" placeholder="Enter ${childProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                      </span>
-                                    </div>
-
-                                    <div if.bind="childProp.isExpanded && childProp.expandedValue" class="property-children">
-                                      <div if.bind="!childProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                      <div repeat.for="nestedProp of childProp.expandedValue.properties" class="child-property">
-                                        <div class="property-row">
-                                          <div
-                                            class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
-                                            click.trigger="handlePropertyRowClick(nestedProp, $event)"
-                                          >
-                                            <button class="expand-button" css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nestedProp)">
-                                              <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nestedProp.isExpanded ? 'expanded' : ''}">
-                                                <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                              </svg>
-                                            </button>
-                                            <span class="property-name">${nestedProp.name}</span>
-                                            <span class="property-separator">:</span>
-                                            <span class="property-value-wrapper">
-                                              <span if.bind="!nestedProp.isEditing" class="property-value ${nestedProp.type} ${nestedProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="nestedProp.canEdit ? editProperty(nestedProp) : null" title="${nestedProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                <span if.bind="nestedProp.type === 'string'">"</span>${nestedProp.value}<span if.bind="nestedProp.type === 'string'">"</span>
-                                              </span>
-                                              <input if.bind="nestedProp.isEditing" class="property-editor" type="text" value.bind="nestedProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(nestedProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(nestedProp) : null)" blur.trigger="saveProperty(nestedProp, $event.target.value)" placeholder="Enter ${nestedProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                            </span>
-                                          </div>
-
-                                          <div if.bind="nestedProp.isExpanded && nestedProp.expandedValue" class="property-children">
-                                            <div if.bind="!nestedProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                            <div repeat.for="deepProp of nestedProp.expandedValue.properties" class="child-property">
-                                              <div class="property-row">
-                                                <div
-                                                  class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
-                                                  click.trigger="handlePropertyRowClick(deepProp, $event)"
-                                                >
-                                                  <button class="expand-button" css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deepProp)">
-                                                    <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deepProp.isExpanded ? 'expanded' : ''}">
-                                                      <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                                    </svg>
-                                                  </button>
-                                                  <span class="property-name">${deepProp.name}</span>
-                                                  <span class="property-separator">:</span>
-                                                  <span class="property-value-wrapper">
-                                                    <span if.bind="!deepProp.isEditing" class="property-value ${deepProp.type} ${deepProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deepProp.canEdit ? editProperty(deepProp) : null" title="${deepProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                      <span if.bind="deepProp.type === 'string'">"</span>${deepProp.value}<span if.bind="deepProp.type === 'string'">"</span>
-                                                    </span>
-                                                    <select if.bind="deepProp.isEditing && deepProp.type === 'boolean'" class="property-editor" value.bind="deepProp.value ? 'true' : 'false'" change.trigger="saveProperty(deepProp, $event.target.value)" blur.trigger="saveProperty(deepProp, $event.target.value)">
-                                                      <option value="true">true</option>
-                                                      <option value="false">false</option>
-                                                    </select>
-                                                    <input if.bind="deepProp.isEditing && deepProp.type !== 'boolean'" class="property-editor" type="text" value.bind="deepProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deepProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deepProp) : null)" blur.trigger="saveProperty(deepProp, $event.target.value)" placeholder="Enter ${deepProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                                  </span>
-                                                </div>
-
-                                                <div if.bind="deepProp.isExpanded && deepProp.expandedValue" class="property-children">
-                                                  <div if.bind="!deepProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                                  <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
-                                                    <div class="property-row">
-                                                      <div
-                                                        class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
-                                                        click.trigger="handlePropertyRowClick(deeperProp, $event)"
-                                                      >
-                                                        <button class="expand-button" css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeperProp)">
-                                                          <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeperProp.isExpanded ? 'expanded' : ''}">
-                                                            <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                                          </svg>
-                                                        </button>
-                                                        <span class="property-name">${deeperProp.name}</span>
-                                                        <span class="property-separator">:</span>
-                                                        <span class="property-value-wrapper">
-                                                          <span if.bind="!deeperProp.isEditing" class="property-value ${deeperProp.type} ${deeperProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deeperProp.canEdit ? editProperty(deeperProp) : null" title="${deeperProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                            <span if.bind="deeperProp.type === 'string'">"</span>${deeperProp.value}<span if.bind="deeperProp.type === 'string'">"</span>
-                                                          </span>
-                                                          <select if.bind="deeperProp.isEditing && deeperProp.type === 'boolean'" class="property-editor" value.bind="deeperProp.value ? 'true' : 'false'" change.trigger="saveProperty(deeperProp, $event.target.value)" blur.trigger="saveProperty(deeperProp, $event.target.value)">
-                                                            <option value="true">true</option>
-                                                            <option value="false">false</option>
-                                                          </select>
-                                                          <input if.bind="deeperProp.isEditing && deeperProp.type !== 'boolean'" class="property-editor" type="text" value.bind="deeperProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deeperProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deeperProp) : null)" blur.trigger="saveProperty(deeperProp, $event.target.value)" placeholder="Enter ${deeperProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                                        </span>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
                               </div>
                             </div>
                           </li>
                         </ul>
                       </div>
 
-                      <!-- Properties -->
+                      <div class="properties-separator"></div>
+
                       <div class="section-header">
                         <span class="section-icon">🏠</span>
                         <span class="section-title">Properties</span>
@@ -1216,145 +639,33 @@
                       <div class="section-content">
                         <div if.bind="!attribute.properties.length" class="empty-state">No properties</div>
                         <ul class="properties-list" else>
-                          <li repeat.for="property of attribute.properties" class="property-item">
+                          <li
+                            repeat.for="row of getPropertyRows(attribute.properties, propertyRowsRevision)"
+                            class="property-item"
+                            style="padding-left: ${row.depth * 16}px"
+                          >
                             <div class="property-row">
                               <div
-                                class="property-main ${property.canExpand ? 'expandable' : ''}"
-                                click.trigger="handlePropertyRowClick(property, $event)"
+                                class="property-main ${row.property.canExpand ? 'expandable' : ''}"
+                                click.trigger="handlePropertyRowClick(row.property, $event)"
                               >
-                                <button class="expand-button" css="visibility: ${property.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(property)">
-                                  <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${property.isExpanded ? 'expanded' : ''}">
+                                <button class="expand-button" css="visibility: ${row.property.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(row.property)">
+                                  <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${row.property.isExpanded ? 'expanded' : ''}">
                                     <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
                                   </svg>
                                 </button>
-                                <span class="property-name">${property.name}</span>
+                                <span class="property-name">${row.property.name}</span>
                                 <span class="property-separator">:</span>
                                 <span class="property-value-wrapper">
-                                  <span if.bind="!property.isEditing" class="property-value ${property.type} ${property.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="property.canEdit ? editProperty(property) : null" title="${property.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                    <span if.bind="property.type === 'string'">"</span>${property.value}<span if.bind="property.type === 'string'">"</span>
+                                  <span if.bind="!row.property.isEditing" class="property-value ${row.property.type} ${row.property.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="row.property.canEdit ? editProperty(row.property) : null" title="${row.property.canEdit ? 'Double-click to edit' : 'Read-only property'}">
+                                    <span if.bind="row.property.type === 'string'">"</span>${row.property.value}<span if.bind="row.property.type === 'string'">"</span>
                                   </span>
-                                  <input if.bind="property.isEditing" class="property-editor" type="text" value.bind="property.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(property, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(property) : null)" blur.trigger="saveProperty(property, $event.target.value)" placeholder="Enter ${property.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
+                                  <select if.bind="row.property.isEditing && row.property.type === 'boolean'" class="property-editor" value.bind="row.property.value ? 'true' : 'false'" change.trigger="saveProperty(row.property, $event.target.value)" blur.trigger="saveProperty(row.property, $event.target.value)">
+                                    <option value="true">true</option>
+                                    <option value="false">false</option>
+                                  </select>
+                                  <input if.bind="row.property.isEditing && row.property.type !== 'boolean'" class="property-editor" type="text" value.bind="row.property.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(row.property, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(row.property) : null)" blur.trigger="saveProperty(row.property, $event.target.value)" placeholder="Enter ${row.property.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
                                 </span>
-                              </div>
-
-                              <div if.bind="property.isExpanded && property.expandedValue" class="property-children">
-                                <div if.bind="!property.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                <div repeat.for="childProp of property.expandedValue.properties" class="child-property">
-                                  <div class="property-row">
-                                    <div
-                                      class="property-main ${childProp.canExpand ? 'expandable' : ''}"
-                                      click.trigger="handlePropertyRowClick(childProp, $event)"
-                                    >
-                                      <button class="expand-button" css="visibility: ${childProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(childProp)">
-                                        <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${childProp.isExpanded ? 'expanded' : ''}">
-                                          <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                        </svg>
-                                      </button>
-                                      <span class="property-name">${childProp.name}</span>
-                                      <span class="property-separator">:</span>
-                                      <span class="property-value-wrapper">
-                                        <span if.bind="!childProp.isEditing" class="property-value ${childProp.type} ${childProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="childProp.canEdit ? editProperty(childProp) : null" title="${childProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                          <span if.bind="childProp.type === 'string'">"</span>${childProp.value}<span if.bind="childProp.type === 'string'">"</span>
-                                        </span>
-                                        <select if.bind="childProp.isEditing && childProp.type === 'boolean'" class="property-editor" value.bind="childProp.value ? 'true' : 'false'" change.trigger="saveProperty(childProp, $event.target.value)" blur.trigger="saveProperty(childProp, $event.target.value)">
-                                          <option value="true">true</option>
-                                          <option value="false">false</option>
-                                        </select>
-                                        <input if.bind="childProp.isEditing && childProp.type !== 'boolean'" class="property-editor" type="text" value.bind="childProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(childProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(childProp) : null)" blur.trigger="saveProperty(childProp, $event.target.value)" placeholder="Enter ${childProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                      </span>
-                                    </div>
-
-                                    <div if.bind="childProp.isExpanded && childProp.expandedValue" class="property-children">
-                                      <div if.bind="!childProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                      <div repeat.for="nestedProp of childProp.expandedValue.properties" class="child-property">
-                                        <div class="property-row">
-                                          <div
-                                            class="property-main ${nestedProp.canExpand ? 'expandable' : ''}"
-                                            click.trigger="handlePropertyRowClick(nestedProp, $event)"
-                                          >
-                                            <button class="expand-button" css="visibility: ${nestedProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(nestedProp)">
-                                              <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${nestedProp.isExpanded ? 'expanded' : ''}">
-                                                <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                              </svg>
-                                            </button>
-                                            <span class="property-name">${nestedProp.name}</span>
-                                            <span class="property-separator">:</span>
-                                            <span class="property-value-wrapper">
-                                              <span if.bind="!nestedProp.isEditing" class="property-value ${nestedProp.type} ${nestedProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="nestedProp.canEdit ? editProperty(nestedProp) : null" title="${nestedProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                <span if.bind="nestedProp.type === 'string'">"</span>${nestedProp.value}<span if.bind="nestedProp.type === 'string'">"</span>
-                                              </span>
-                                              <select if.bind="nestedProp.isEditing && nestedProp.type === 'boolean'" class="property-editor" value.bind="nestedProp.value ? 'true' : 'false'" change.trigger="saveProperty(nestedProp, $event.target.value)" blur.trigger="saveProperty(nestedProp, $event.target.value)">
-                                                <option value="true">true</option>
-                                                <option value="false">false</option>
-                                              </select>
-                                              <input if.bind="nestedProp.isEditing && nestedProp.type !== 'boolean'" class="property-editor" type="text" value.bind="nestedProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(nestedProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(nestedProp) : null)" blur.trigger="saveProperty(nestedProp, $event.target.value)" placeholder="Enter ${nestedProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                            </span>
-                                          </div>
-
-                                          <div if.bind="nestedProp.isExpanded && nestedProp.expandedValue" class="property-children">
-                                            <div if.bind="!nestedProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                            <div repeat.for="deepProp of nestedProp.expandedValue.properties" class="child-property">
-                                              <div class="property-row">
-                                                <div
-                                                  class="property-main ${deepProp.canExpand ? 'expandable' : ''}"
-                                                  click.trigger="handlePropertyRowClick(deepProp, $event)"
-                                                >
-                                                  <button class="expand-button" css="visibility: ${deepProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deepProp)">
-                                                    <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deepProp.isExpanded ? 'expanded' : ''}">
-                                                      <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                                    </svg>
-                                                  </button>
-                                                  <span class="property-name">${deepProp.name}</span>
-                                                  <span class="property-separator">:</span>
-                                                  <span class="property-value-wrapper">
-                                                    <span if.bind="!deepProp.isEditing" class="property-value ${deepProp.type} ${deepProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deepProp.canEdit ? editProperty(deepProp) : null" title="${deepProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                      <span if.bind="deepProp.type === 'string'">"</span>${deepProp.value}<span if.bind="deepProp.type === 'string'">"</span>
-                                                    </span>
-                                                    <select if.bind="deepProp.isEditing && deepProp.type === 'boolean'" class="property-editor" value.bind="deepProp.value ? 'true' : 'false'" change.trigger="saveProperty(deepProp, $event.target.value)" blur.trigger="saveProperty(deepProp, $event.target.value)">
-                                                      <option value="true">true</option>
-                                                      <option value="false">false</option>
-                                                    </select>
-                                                    <input if.bind="deepProp.isEditing && deepProp.type !== 'boolean'" class="property-editor" type="text" value.bind="deepProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deepProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deepProp) : null)" blur.trigger="saveProperty(deepProp, $event.target.value)" placeholder="Enter ${deepProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                                  </span>
-                                                </div>
-
-                                                <div if.bind="deepProp.isExpanded && deepProp.expandedValue" class="property-children">
-                                                  <div if.bind="!deepProp.expandedValue.properties.length" class="empty-object">Object has no enumerable properties</div>
-                                            <div repeat.for="deeperProp of deepProp.expandedValue.properties" class="child-property">
-                                              <div class="property-row">
-                                                <div
-                                                  class="property-main ${deeperProp.canExpand ? 'expandable' : ''}"
-                                                  click.trigger="handlePropertyRowClick(deeperProp, $event)"
-                                                >
-                                                        <button class="expand-button" css="visibility: ${deeperProp.canExpand ? 'visible' : 'hidden'}" click.trigger="togglePropertyExpansion(deeperProp)">
-                                                          <svg width="8" height="8" viewBox="0 0 8 8" class="expand-icon ${deeperProp.isExpanded ? 'expanded' : ''}">
-                                                            <path d="M2 2 L6 4 L2 6 Z" fill="currentColor" />
-                                                          </svg>
-                                                        </button>
-                                                        <span class="property-name">${deeperProp.name}</span>
-                                                        <span class="property-separator">:</span>
-                                                        <span class="property-value-wrapper">
-                                                          <span if.bind="!deeperProp.isEditing" class="property-value ${deeperProp.type} ${deeperProp.canEdit ? 'editable' : 'readonly'}" dblclick.trigger="deeperProp.canEdit ? editProperty(deeperProp) : null" title="${deeperProp.canEdit ? 'Double-click to edit' : 'Read-only property'}">
-                                                            <span if.bind="deeperProp.type === 'string'">"</span>${deeperProp.value}<span if.bind="deeperProp.type === 'string'">"</span>
-                                                          </span>
-                                                          <select if.bind="deeperProp.isEditing && deeperProp.type === 'boolean'" class="property-editor" value.bind="deeperProp.value ? 'true' : 'false'" change.trigger="saveProperty(deeperProp, $event.target.value)" blur.trigger="saveProperty(deeperProp, $event.target.value)">
-                                                            <option value="true">true</option>
-                                                            <option value="false">false</option>
-                                                          </select>
-                                                          <input if.bind="deeperProp.isEditing && deeperProp.type !== 'boolean'" class="property-editor" type="text" value.bind="deeperProp.value" keydown.trigger="$event.code === 'Enter' ? saveProperty(deeperProp, $event.target.value) : ($event.code === 'Escape' ? cancelPropertyEdit(deeperProp) : null)" blur.trigger="saveProperty(deeperProp, $event.target.value)" placeholder="Enter ${deeperProp.type} value (ESC to cancel)" focus.trigger="$event.target.select()" />
-                                                        </span>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
                               </div>
                             </div>
                           </li>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,9 +29,23 @@ export interface IControllerInfo {
 }
 
 export type AureliaInfo = {
-  customElementInfo: IControllerInfo;
+  customElementInfo: IControllerInfo | null;
   customAttributesInfo: IControllerInfo[];
 };
+
+export interface AureliaComponentTreeNode {
+  id: string;
+  domPath: string;
+  tagName: string | null;
+  customElementInfo: IControllerInfo | null;
+  customAttributesInfo: IControllerInfo[];
+  children: AureliaComponentTreeNode[];
+}
+
+export interface AureliaComponentSnapshot {
+  tree: AureliaComponentTreeNode[];
+  flat: AureliaInfo[];
+}
 
 export interface AureliaHooks {
   currentAttributes: IComponentController[];

--- a/src/styles.css
+++ b/src/styles.css
@@ -420,8 +420,12 @@
     @apply py-2;
   }
   
+  .component-tree-row {
+    @apply w-full;
+  }
+  
   .component-item {
-    @apply flex items-center px-4 py-1 cursor-pointer transition-colors min-h-6;
+    @apply flex items-center gap-2 py-1 pr-4 cursor-pointer transition-colors min-h-6 rounded-sm;
   }
   
   .component-item:hover {
@@ -431,6 +435,10 @@
   .component-item.selected {
     @apply bg-blue-50 text-blue-600 font-medium;
   }
+
+  .component-item.selected .component-name.custom-attribute {
+    @apply text-red-600;
+  }
   
   .dark .component-item:hover {
     @apply bg-gray-800;
@@ -439,10 +447,18 @@
   .dark .component-item.selected {
     @apply bg-blue-900 text-blue-400;
   }
+
+  .dark .component-item.selected .component-name.custom-attribute {
+    @apply text-red-300;
+  }
   
   .expand-toggle {
     @apply bg-transparent border-none p-0 mr-1 w-3 h-3 flex items-center justify-center 
            cursor-pointer text-gray-600;
+  }
+
+  .expand-toggle[disabled] {
+    @apply cursor-default opacity-60;
   }
   
   .expand-toggle:hover {
@@ -466,7 +482,7 @@
   }
   
   .component-icon {
-    @apply mr-1.5 flex items-center flex-shrink-0;
+    @apply flex items-center flex-shrink-0;
   }
   
   .component-icon.custom-element {
@@ -507,15 +523,75 @@
   }
   
   .component-badge {
-    @apply bg-blue-50 text-blue-600 text-xs font-semibold px-1 rounded-full ml-2 min-w-4 text-center;
+    @apply bg-blue-50 text-blue-600 text-[10px] font-semibold px-1 rounded-full ml-2 min-w-4 text-center;
   }
   
   .dark .component-badge {
     @apply bg-blue-900 text-blue-400;
   }
   
-  .component-children {
-    @apply ml-5 border-l border-gray-100;
+  .view-mode-toggle {
+    @apply flex items-center gap-1 ml-2;
+  }
+
+  .view-mode-icon {
+    @apply text-sm leading-none;
+  }
+
+  .component-breadcrumbs {
+    @apply flex items-center gap-1 text-[11px] text-gray-500 mb-2 flex-wrap;
+  }
+
+  .component-breadcrumbs .breadcrumb-item {
+    @apply bg-transparent border-none px-1 py-0.5 rounded-sm cursor-pointer text-gray-600;
+  }
+
+  .component-breadcrumbs .breadcrumb-item.custom-element {
+    @apply text-blue-600;
+  }
+
+  .component-breadcrumbs .breadcrumb-item.custom-attribute {
+    @apply text-red-600 italic;
+  }
+
+  .component-breadcrumbs .breadcrumb-item:hover {
+    @apply bg-gray-100 text-gray-800;
+  }
+
+  .component-breadcrumbs .breadcrumb-item.active {
+    @apply font-medium bg-blue-50;
+  }
+
+  .dark .component-breadcrumbs {
+    @apply text-gray-400;
+  }
+
+  .dark .component-breadcrumbs .breadcrumb-item {
+    @apply text-gray-300;
+  }
+
+  .dark .component-breadcrumbs .breadcrumb-item.custom-element {
+    @apply text-blue-300;
+  }
+
+  .dark .component-breadcrumbs .breadcrumb-item.custom-attribute {
+    @apply text-red-300 italic;
+  }
+
+  .dark .component-breadcrumbs .breadcrumb-item:hover {
+    @apply bg-white/10 text-gray-100;
+  }
+
+  .dark .component-breadcrumbs .breadcrumb-item.active {
+    @apply font-medium bg-blue-900;
+  }
+
+  .breadcrumb-separator {
+    @apply text-gray-400 text-xs;
+  }
+
+  .dark .breadcrumb-separator {
+    @apply text-gray-500;
   }
   
   .dark .component-children {
@@ -600,7 +676,19 @@
   }
   
   .property-main {
-    @apply flex items-center py-0 min-h-4;
+    @apply flex items-center py-0 min-h-4 gap-1.5;
+  }
+
+  .property-main.expandable {
+    @apply cursor-pointer;
+  }
+
+  .property-main.expandable:hover .property-name {
+    @apply text-blue-600;
+  }
+
+  .dark .property-main.expandable:hover .property-name {
+    @apply text-blue-300;
   }
   
   .property-name {
@@ -680,6 +768,26 @@
   .property-value.function {
     color: var(--color-syntax-boolean);
     @apply font-medium italic;
+  }
+
+  .expand-button {
+    @apply flex items-center justify-center w-5 h-5 mr-2 rounded-sm border border-transparent text-gray-500;
+  }
+
+  .expand-button:hover {
+    @apply bg-gray-200 border-gray-300;
+  }
+
+  .dark .expand-button {
+    @apply text-gray-300;
+  }
+
+  .dark .expand-button:hover {
+    @apply bg-gray-700 border-gray-600;
+  }
+
+  .expand-button svg {
+    pointer-events: none;
   }
   
   .dark .property-value:hover {

--- a/tests/debug-host-extra.spec.ts
+++ b/tests/debug-host-extra.spec.ts
@@ -5,8 +5,8 @@ import { DebugHost } from '@/backend/debug-host';
 class ConsumerStub {
   followChromeSelection = false;
   onElementPicked = jest.fn();
-  buildComponentTree = jest.fn();
-  allAureliaObjects: any[] = [];
+  handleComponentSnapshot = jest.fn();
+  componentSnapshot = { tree: [], flat: [] };
 }
 
 describe('DebugHost additional behaviors', () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -8,7 +8,7 @@ export function stubPlatform() {
 
 export function stubDebugHost(overrides: Partial<Record<string, any>> = {}) {
   return {
-    getAllComponents: jest.fn().mockResolvedValue([]),
+    getAllComponents: jest.fn().mockResolvedValue({ tree: [], flat: [] }),
     updateValues: jest.fn(),
     highlightComponent: jest.fn(),
     unhighlightComponent: jest.fn(),


### PR DESCRIPTION
This addresses all the feedback in this issue https://github.com/aurelia/devtools/issues/1

Most notably:

- Implemented the Aurelia UI right in the Elements panel. Some users said they liked having this in Elements, so using the new UI we added this into the elements panel and allows selecting HTML and automatically highlighting it in the Aurelia devtools panel to get information
- Fixed depth issue for expanding child object paths
- Fixed up path traversal logic
- Fixed issue where components of same type were not being differentiated correctly in all circumstances
- Fixed issue around selecting component and getting component container
- Tree and list view options
- Cleanup up spacing/indentation as well as iconography
- Lots of cleanup of other things found along the way